### PR TITLE
Fixed small error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ console.log('%c a nested log with styling', 'color: #D63230;');
 console.groupEnd();
 console.log('almost done');
 console.groupEnd();
-console.info('fin', 'font-weight: bold;');
+console.info('%c fin', 'font-weight: bold;');
 ```
 
 #### `console.history();`


### PR DESCRIPTION
Fixed small error in documentation (README.md) where ```font-weight:bold;``` wasn't applied to text.