### PR TITLE
Rename deprecated script prepublish to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prettier": "prettier --single-quote --trailing-comma es5 --write \"{src,__{tests,mocks}__}/**/*.js\"",
     "check": "yarn run lint && jest --coverage",
     "build": "babel src --out-dir lib --ignore __tests__",
-    "prepublish": "yarn run build"
+    "prepublishOnly": "yarn run build"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Right now, `yarn`/`npm install` end up running the build script:
```
λ yarn
yarn install v1.3.2
[1/4] Resolving packages...
success Already up-to-date.
$ yarn run build
yarn run v1.3.2
$ babel src --out-dir lib --ignore __tests__
src\consolemock.js -> lib\consolemock.js
src\index.js -> lib\index.js
src\print-line.js -> lib\print-line.js
Done in 6.25s.
Done in 7.48s.
```
This switches deprecated script `prepublish` to `prepublishOnly`. 

Relevant article - http://blog.lholmquist.org/npm-prepublish-changes/